### PR TITLE
Add JSX runtime

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
 		'linebreak-style': ['error', 'unix'],
 		'no-console': 0,
 		'no-tabs': 0,
+		'react/jsx-key': 0,
 		'react/prop-types': 0,
 		'sort-keys': ['error', 'asc', { caseSensitive: true, minKeys: 2, natural: true }],
 		'space-before-function-paren': [

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -83,5 +83,49 @@ export default [
 			}),
 			buble()
 		].concat(isProduction ? [terserConfig] : [])
+	},
+	{
+		input: 'src/jsx-runtime.ts',
+		output: [
+			{
+				banner,
+				file: `${dir}/jsx-runtime.esm.js`,
+				format: 'es'
+			},
+			{
+				banner,
+				file: `${dir}/jsx-runtime.cjs.js`,
+				format: 'cjs'
+			}
+		],
+		plugins: [
+			typescript({
+				include: 'src/**',
+				typescript: require('typescript')
+			}),
+			buble()
+		].concat(isProduction ? [terserConfig] : [])
+	},
+	{
+		input: 'src/jsx-dev-runtime.ts',
+		output: [
+			{
+				banner,
+				file: `${dir}/jsx-dev-runtime.esm.js`,
+				format: 'es'
+			},
+			{
+				banner,
+				file: `${dir}/jsx-dev-runtime.cjs.js`,
+				format: 'cjs'
+			}
+		],
+		plugins: [
+			typescript({
+				include: 'src/**',
+				typescript: require('typescript')
+			}),
+			buble()
+		].concat(isProduction ? [terserConfig] : [])
 	}
 ]

--- a/package.json
+++ b/package.json
@@ -41,6 +41,18 @@
 			"import": "./dist/jsx.esm.mjs",
 			"require": "./dist/jsx.cjs.js",
 			"default": "./dist/jsx.js"
+		},
+		"./jsx-runtime": {
+			"types": "./types/jsx.d.ts",
+			"import": "./dist/jsx-runtime.esm.js",
+			"require": "./dist/jsx-runtime.cjs.js",
+			"default": "./dist/jsx-runtime.cjs.js"
+		},
+		"./jsx-dev-runtime": {
+			"types": "./types/jsx.d.ts",
+			"import": "./dist/jsx-dev-runtime.esm.js",
+			"require": "./dist/jsx-dev-runtime.cjs.js",
+			"default": "./dist/jsx-dev-runtime.cjs.js"
 		}
 	},
 	"main": "dist/costro.cjs.js",

--- a/src/jsx-dev-runtime.ts
+++ b/src/jsx-dev-runtime.ts
@@ -1,0 +1,1 @@
+export { jsx, jsx as jsxs, jsx as jsxDEV, Fragment } from './jsx'

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,0 +1,1 @@
+export { jsx, jsx as jsxs, jsx as jsxDEV, Fragment } from './jsx'

--- a/tests/unit/jsx.test.js
+++ b/tests/unit/jsx.test.js
@@ -1,6 +1,30 @@
-import { createElement, Fragment, h } from '@src/jsx'
+import { createElement, Fragment, jsx, h } from '@src/jsx'
 
 describe('JSX', () => {
+	describe('jsx to support automatic runtime', () => {
+		it('Should call the jsx function with an empty div', () => {
+			const result = jsx('div', {})
+			expect(result.outerHTML).toStrictEqual('<div></div>')
+		})
+
+		it('Should call the jsx function with a div and a single child as text', () => {
+			const result = jsx('div', { children: 'Hello' })
+			expect(result.outerHTML).toStrictEqual('<div>Hello</div>')
+		})
+
+		it('Should call the jsx function with a div and a single chil as element', () => {
+			const result = jsx('div', { children: <p>Hello</p> })
+			expect(result.outerHTML).toStrictEqual('<div><p>Hello</p></div>')
+		})
+
+		it('Should call the jsx function with a div and multiple children as element', () => {
+			const result = jsx('div', {
+				children: [<p>Hello</p>, <span>guys</span>]
+			})
+			expect(result.outerHTML).toStrictEqual('<div><p>Hello</p><span>guys</span></div>')
+		})
+	})
+
 	describe('createElement', () => {
 		it('Should call the createElement function with a string tag and without attribute', () => {
 			const result = createElement('div', null)


### PR DESCRIPTION
## New JSX transform

### Automatic runtime <kbd>Recommanded</kbd>

**babel.config.js**

```json
{
  "presets": [
    [
      "@babel/preset-react",
      {
        "runtime": "automatic",
        "importSource": "costro"
      }
    ]
  ]
}
```

**main.js**

```diff
- import { h, F } from 'costro/jsx';
```

### Classic runtime

**babel.config.js**

```json
{
  "presets": [
    [
      "@babel/preset-react",
      {
        "runtime": "classic",
        "pragma": "h",
        "pragmaFrag": "F"
      }
    ]
  ]
}
```

**main.js**

```diff
- import { h, F } from 'costro/jsx';
```

### TypeScript

**tsconfig.json**

```json
{
  "jsx": "react-jsx",
  "jsxImportSource": "costro",
  "jsxFactory": "h",
  "jsxFragmentFactory": "F"
}
```

> **Note** JSX declarations are not included, may caused warning if JSX syntax is used without Costro

## Old JSX transform

**babel.config.js**

```json
{
  "plugins": [
    [
      "@babel/plugin-transform-react-jsx",
      {
        "pragma": "h",
        "pragmaFrag": "F"
      }
    ]
  ]
}
```

**main.js**

```diff
+ import { h, F } from 'costro/jsx';
```

## Docs

- https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
- https://babeljs.io/docs/babel-preset-react
